### PR TITLE
Trim characters not in alphabet, and other minors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   Implementation of an enigma machine
 
 ## Installation
-  
+
     $ npm install enigma
 
 ## Example
@@ -14,11 +14,11 @@ var enigmajs = require('enigma');
 var rotorI        = new enigmajs.Rotor('EKMFLGDQVZNTOWYHXUSPAIBRCJ', 'Q');
 var rotorIII      = new enigmajs.Rotor('BDFHJLCPRTXVZNYEIWGAKMUSQO', 'V');
 var rotorIV       = new enigmajs.Rotor('ESOVPZJAYQUIRHXLNFTGKDCMWB', 'J');
-var ukwB          = new enigmajs.Umkehrwalze('YRUHQSLDPXNGOKMIEBFZCWVJAT');
-var steckerbrett  = new enigmajs.Steckerbrett( 'AD CN ET FL GI JV KZ PU QY WX' );
-var etw           = new enigmajs.Eintrittswalze('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+var reflector     = new enigmajs.Reflector('YRUHQSLDPXNGOKMIEBFZCWVJAT');
+var plugboard     = new enigmajs.Plugboard( 'AD CN ET FL GI JV KZ PU QY WX' );
+var entryWheel    = new enigmajs.EntryWheel('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
 
-var enigma = new enigmajs.Enigma([rotorI, rotorIV, rotorIII], ukwB, steckerbrett, etw);
+var enigma = new enigmajs.Enigma([rotorI, rotorIV, rotorIII], reflector, plugboard, entryWheel);
 
 console.log( enigma.string( 'EXAMPLEMESSAGE' ) );
 ```
@@ -27,7 +27,7 @@ Prints out `RRHIUUFUVJLJYY`
 You should also have a look at [this test](test/enigma-realmessage.js) which demonstrates a more realistic procedure to cipher/decipher a message.
 
 ## Testing
-  
+
     $ npm test
 
   [![Build Status](https://travis-ci.org/benelsen/enigma.png?branch=master)](https://travis-ci.org/benelsen/enigma)

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -3,10 +3,10 @@ var enigmajs = require('../');
 var rotorI        = new enigmajs.Rotor('EKMFLGDQVZNTOWYHXUSPAIBRCJ', 'Q');
 var rotorIII      = new enigmajs.Rotor('BDFHJLCPRTXVZNYEIWGAKMUSQO', 'V');
 var rotorIV       = new enigmajs.Rotor('ESOVPZJAYQUIRHXLNFTGKDCMWB', 'J');
-var ukwB          = new enigmajs.Umkehrwalze('YRUHQSLDPXNGOKMIEBFZCWVJAT');
-var steckerbrett  = new enigmajs.Steckerbrett( 'AD CN ET FL GI JV KZ PU QY WX' );
-var etw           = new enigmajs.Eintrittswalze('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+var reflector     = new enigmajs.Reflector('YRUHQSLDPXNGOKMIEBFZCWVJAT');
+var plugboard     = new enigmajs.Plugboard( 'AD CN ET FL GI JV KZ PU QY WX' );
+var entryWheel    = new enigmajs.EntryWheel('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
 
-var enigma = new enigmajs.Enigma([rotorI, rotorIV, rotorIII], ukwB, steckerbrett, etw);
+var enigma = new enigmajs.Enigma([rotorI, rotorIV, rotorIII], reflector, plugboard, entryWheel);
 
 console.log( enigma.string( 'EXAMPLEMESSAGE' ) );

--- a/lib/enigma.js
+++ b/lib/enigma.js
@@ -5,8 +5,8 @@ function Enigma(rotors, ukw, steckerbrett, etw) {
 
   this.alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
-  if ( (rotors.length < 3 || rotors.length > 4) && typeof ukw === 'undefined' && typeof steckerbrett === 'undefined' && typeof etw === 'undefined') {
-    throw new Error('Only three or four rotors are supported.');
+  if ( (rotors.length < 3 || rotors.length > 4) || typeof ukw === 'undefined' || typeof steckerbrett === 'undefined' || typeof etw === 'undefined') {
+    throw new Error('Only three or four rotors are supported, and reflector, plugboard and entry wheel must be set');
   }
 
   this.rotors = rotors;
@@ -65,7 +65,9 @@ Enigma.prototype.rotate = function() {
 };
 
 Enigma.prototype.string = function(string) {
-  string = typeof string === 'string' ? string.toUpperCase().split('') : string;
+  // Convert argument to string, upper case, and remove illegal letters (such as spaces)
+  string = typeof string === 'string' ? string : string.toString();
+  string = string.toUpperCase().replace(new RegExp('[^' + this.etw.wiring + ']','g'), '').split('');
 
   var res = '';
   for (var i = 0; i < string.length; i++) {


### PR DESCRIPTION
- Added support to spaces (and other characters) in plain text messages (they are trimmed), and accepted objects as arguments to enigma.string (they must implement toString).
- Fixed error message then arguments are not correct when creating a Enigma
- Modified example to use English aliases.
